### PR TITLE
fix #69 - enforce unique bids per user per url

### DIFF
--- a/auctions/migrations/0005_auto_20150103_0221.py
+++ b/auctions/migrations/0005_auto_20150103_0221.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auctions', '0004_auto_20141227_1923'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='bid',
+            unique_together=set([('user', 'url')]),
+        ),
+    ]

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -17,6 +17,9 @@ class Bid(models.Model):
     ask_match_sent = models.DateTimeField(null=True, blank=True)
     offer = models.DecimalField(max_digits=6, decimal_places=2)
 
+    class Meta:
+        unique_together = (("user", "url"),)
+
 
 @receiver(post_save, sender=Bid)
 def notify_matching_askers(sender, instance, **kwargs):


### PR DESCRIPTION
I spot-checked by:

1. Open the chrome extension to an issue
2. Alter the bid form:
  * remove the _method=PUT hidden input and 
  * drop the bid ID from the action url
3. Submit the form

* [ ] Verify you get a 400 Bad Request
* [ ] BONUS! Check the error response says user, url must be a unique set