### PR TITLE
fix #74 - remove EMAIL_BACKEND; add DEFAULT_FROM_EMAIL

### DIFF
--- a/codesy/settings.py
+++ b/codesy/settings.py
@@ -166,6 +166,7 @@ SWAGGER_SETTINGS = {
     'exclude_namespaces': ['single_bid']
 }
 
+DEFAULT_FROM_EMAIL = 'notifications@api.codesy.io'
 EMAIL_HOST = 'smtp.sendgrid.net'
 EMAIL_HOST_USER = config('SENDGRID_USERNAME', default='')
 EMAIL_HOST_PASSWORD = config('SENDGRID_PASSWORD', default='')

--- a/codesy/settings.py
+++ b/codesy/settings.py
@@ -166,8 +166,6 @@ SWAGGER_SETTINGS = {
     'exclude_namespaces': ['single_bid']
 }
 
-EMAIL_BACKEND = config('EMAIL_BACKEND',
-                       'django.core.mail.backends.smtp.EmailBackend')
 EMAIL_HOST = 'smtp.sendgrid.net'
 EMAIL_HOST_USER = config('SENDGRID_USERNAME', default='')
 EMAIL_HOST_PASSWORD = config('SENDGRID_PASSWORD', default='')


### PR DESCRIPTION
We use django-mailer's `send_mail` function explicitly, so we don't need to configure it as the global EMAIL_BACKEND.