### PR TITLE
fix #161 - add evidence field to claims

### DIFF
--- a/auctions/migrations/0009_claim_evidence.py
+++ b/auctions/migrations/0009_claim_evidence.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auctions', '0008_auto_20150301_1953'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='claim',
+            name='evidence',
+            field=models.URLField(blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -99,9 +99,11 @@ class Claim(models.Model):
         (REJECTED, 'Rejected'),
     )
     issue = models.ForeignKey('Issue')
+    # TODO: rename Claim.claimant to Claim.user
     claimant = models.ForeignKey(settings.AUTH_USER_MODEL)
     created = models.DateTimeField(null=True, blank=True)
     modified = models.DateTimeField(null=True, blank=True, auto_now=True)
+    evidence = models.URLField(blank=True)
     status = models.CharField(max_length=2,
                               choices=STATUS_CHOICES,
                               default=OPEN)

--- a/auctions/serializers.py
+++ b/auctions/serializers.py
@@ -23,5 +23,5 @@ class ClaimSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Claim
-        fields = ('id', 'issue', 'claimant', 'status')
+        fields = ('id', 'issue', 'claimant', 'evidence', 'status')
         read_only_fields = ('id',)

--- a/auctions/templates/includes/claim_form.html
+++ b/auctions/templates/includes/claim_form.html
@@ -5,7 +5,13 @@
           {% csrf_token %}
           <fieldset>
               <input name="issue" type="hidden" value="{{ bid.issue.id }}" />
+              <p>
+              <label for="evidence">Evidence (URL):</label><br/>
+              <input name="evidence" type="text" />
+              </p>
+              <p>
               <input class="pure-button button-success" type="submit" value="Claim the payout for this issue" />
+              </p>
           </fieldset>
       </form>
 {% endif %}

--- a/auctions/tests/serializer_tests.py
+++ b/auctions/tests/serializer_tests.py
@@ -29,6 +29,7 @@ class ClaimSerializerTest(TestCase):
             rest_framework.serializers.ModelSerializer)
         self.assertEqual(self.serializer.Meta.model, models.Claim)
         self.assertSequenceEqual(
-            self.serializer.Meta.fields, ('id', 'issue', 'claimant', 'status'))
+            self.serializer.Meta.fields, ('id', 'issue', 'claimant',
+                                          'evidence', 'status'))
         self.assertSequenceEqual(
             self.serializer.Meta.read_only_fields, ('id',))


### PR DESCRIPTION
I need @jgmize or someone to tell me why https://127.0.0.1:8443/claim/confirmation?bid=11 is getting a 404 and not matching against [the `claim-by-bid` url pattern](https://github.com/codesy/codesy/blob/ca4a4cc82c65814917451003b350052e85877e81/auctions/urls.py#L15-L19)?