### PR TITLE
separate css for iframe widget

### DIFF
--- a/auctions/templates/base_widget.html
+++ b/auctions/templates/base_widget.html
@@ -1,11 +1,18 @@
 {% load staticfiles %}
-<link rel="stylesheet" href="//{{current_site.domain}}{% static "css/styles.css" %}">
-<link rel="stylesheet" href="//cdn.jsdelivr.net/pure/0.5.0/pure-min.css">
 
-<div id="codesy_widget">
-  <a href="https://{{current_site.domain}}" target="_blank">
-    <img id="codesy_logo" class="pure-img" src="https://{{current_site.domain}}{% static "img/codesy_300dpi_323x80.png" %}"/>
-  </a>
-   {% block widget_content %}{% endblock %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+   <link rel="stylesheet" href="//{{current_site.domain}}{% static "css/styles.css" %}">
+   <link rel="stylesheet" href="//cdn.jsdelivr.net/pure/0.5.0/pure-min.css">
+</head>
 
-</div>
+<body>
+   <div id="codesy_div" >
+     <a href="https://{{current_site.domain}}" target="_blank">
+       <img id="codesy_logo" class="pure-img" src="https://{{current_site.domain}}{% static "img/codesy_300dpi_323x80.png" %}"/>
+     </a>
+      {% block widget_content %}{% endblock %}
+   </div>
+</body>
+

--- a/codesy/settings.py
+++ b/codesy/settings.py
@@ -69,7 +69,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/static/css/codesy-iframe.css
+++ b/static/css/codesy-iframe.css
@@ -1,0 +1,9 @@
+#codesy_iframe {
+  max-width:150px;
+  position: fixed;
+  bottom: .25em;
+  right: .25em;
+  border-style:ridge;
+  padding:1%;
+  background: antiquewhite;
+}

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -2,11 +2,11 @@
 .glyphicon-ok {
   color: #5CB85C;
 }
-
+/*
 iframe {
   margin-top: 20px;
 }
-
+*/
 .spin {
   -webkit-animation: spin 2s infinite linear;
   animation: spin 2s infinite linear;
@@ -22,7 +22,7 @@ iframe {
 }
 
 
-/* codesy widget styles */
+/* codesy widget styles */
 
 /* override pure CSS list styling that breaks github lists */
 menu, ol, ul {

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
 
 [flake8]
 exclude=.?*,migrations
+ignore=W503
 
 [testenv:style]
 deps =


### PR DESCRIPTION
Also removes click-jacking middleware protection. See https://github.com/codesy/codesy/issues/185 for replacement click-jacking protection.