### PR TITLE
Add Vote model & VoteViewSet

### DIFF
--- a/auctions/admin.py
+++ b/auctions/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 
-from .models import Bid, Issue, Claim
+from .models import Bid, Issue, Claim, Vote
 
 admin.site.register(Bid)
 admin.site.register(Issue)
 admin.site.register(Claim)
+admin.site.register(Vote)

--- a/auctions/migrations/0010_vote.py
+++ b/auctions/migrations/0010_vote.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('auctions', '0009_claim_evidence'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Vote',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('approved', models.BooleanField(default=None)),
+                ('created', models.DateTimeField(null=True, blank=True)),
+                ('modified', models.DateTimeField(auto_now=True, null=True)),
+                ('claim', models.ForeignKey(to='auctions.Claim')),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/auctions/migrations/0011_auto_20160214_1622.py
+++ b/auctions/migrations/0011_auto_20160214_1622.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auctions', '0010_vote'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='claim',
+            old_name='claimant',
+            new_name='user',
+        ),
+        migrations.AlterUniqueTogether(
+            name='claim',
+            unique_together=set([('user', 'issue')]),
+        ),
+    ]

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.db import models
@@ -110,7 +110,7 @@ class Claim(models.Model):
 
     @property
     def expires(self):
-        return self.created + datetime.timedelta(days=30)
+        return self.created + timedelta(days=30)
 
 
 class Vote(models.Model):

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -104,8 +104,7 @@ class Claim(models.Model):
         (REJECTED, 'Rejected'),
     )
     issue = models.ForeignKey('Issue')
-    # TODO: rename Claim.claimant to Claim.user
-    claimant = models.ForeignKey(settings.AUTH_USER_MODEL)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
     created = models.DateTimeField(null=True, blank=True)
     modified = models.DateTimeField(null=True, blank=True, auto_now=True)
     evidence = models.URLField(blank=True)
@@ -114,11 +113,11 @@ class Claim(models.Model):
                               default=OPEN)
 
     class Meta:
-        unique_together = (("claimant", "issue"),)
+        unique_together = (("user", "issue"),)
 
     def __unicode__(self):
         return u'%s claim on Issue %s (%s)' % (
-            self.claimant, self.issue.id, self.status
+            self.user, self.issue.id, self.status
         )
 
     @property
@@ -147,7 +146,7 @@ def notify_matching_offerers(sender, instance, created, **kwargs):
     """
     current_site = Site.objects.get_current()
 
-    self_Q = models.Q(user=instance.claimant)
+    self_Q = models.Q(user=instance.user)
     offered0_Q = models.Q(offer=0)
     others_bids = Bid.objects.filter(
         issue=instance.issue
@@ -159,10 +158,10 @@ def notify_matching_offerers(sender, instance, created, **kwargs):
         send_mail(
             "[codesy] %(user)s has claimed payout for %(url)s" %
             (
-                {'user': instance.claimant, 'url': instance.issue.url}
+                {'user': instance.user, 'url': instance.issue.url}
             ),
             OFFERER_NOTIFICATION_EMAIL_STRING.format(
-                user=instance.claimant,
+                user=instance.user,
                 url=instance.issue.url,
                 offer=bid.offer,
                 pay_date=instance.expires,

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -147,10 +147,12 @@ def notify_matching_offerers(sender, instance, created, **kwargs):
     """
     current_site = Site.objects.get_current()
 
+    self_Q = models.Q(user=instance.claimant)
+    offered0_Q = models.Q(offer=0)
     others_bids = Bid.objects.filter(
         issue=instance.issue
     ).exclude(
-        user=instance.claimant
+        self_Q | offered0_Q
     )
 
     for bid in others_bids:

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -111,3 +111,16 @@ class Claim(models.Model):
     @property
     def expires(self):
         return self.created + datetime.timedelta(days=30)
+
+
+class Vote(models.Model):
+    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    claim = models.ForeignKey(Claim)
+    approved = models.BooleanField(default=None, blank=True)
+    created = models.DateTimeField(null=True, blank=True)
+    modified = models.DateTimeField(null=True, blank=True, auto_now=True)
+
+    def __unicode__(self):
+        return u'Vote for %s by (%s): %s' % (
+            self.claim, self.user, self.approved
+        )

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 
 from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Sum
 from django.db.models.signals import post_save
@@ -40,7 +42,7 @@ class Bid(models.Model):
 @receiver(post_save, sender=Bid)
 def notify_matching_askers(sender, instance, **kwargs):
     # TODO: make a nicer HTML email template
-    NOTIFICATION_EMAIL_STRING = """
+    ASKER_NOTIFICATION_EMAIL_STRING = """
     Bidders have met your asking price for {url}.
 
     If you fix the issue, you may claim the payout by visiting the issue url:
@@ -61,12 +63,22 @@ def notify_matching_askers(sender, instance, **kwargs):
                 (
                     {'ask': bid.ask, 'url': bid.url}
                 ),
-                NOTIFICATION_EMAIL_STRING.format(url=bid.url),
+                ASKER_NOTIFICATION_EMAIL_STRING.format(url=bid.url),
                 settings.DEFAULT_FROM_EMAIL,
                 [bid.user.email]
             )
             # use .update to avoid recursive signal processing
             Bid.objects.filter(id=bid.id).update(ask_match_sent=datetime.now())
+
+
+@receiver(post_save, sender=Bid)
+def create_issue_for_bid(sender, instance, **kwargs):
+    issue, created = Issue.objects.get_or_create(
+        url=instance.url,
+        defaults={'state': 'unknown', 'last_fetched': None}
+    )
+    # use .update to avoid recursive signal processing
+    Bid.objects.filter(id=instance.id).update(issue=issue)
 
 
 class Issue(models.Model):
@@ -79,6 +91,7 @@ class Issue(models.Model):
 
 
 class Claim(models.Model):
+    # TODO: clean up Claim.status choices
     OPEN = 'OP'
     ESCROW = 'ES'
     PAID = 'PA'
@@ -111,6 +124,52 @@ class Claim(models.Model):
     @property
     def expires(self):
         return self.created + timedelta(days=30)
+
+    # TODO: Claim.get_absolute_url should return claim-status/<pk>
+    def get_absolute_url(self):
+        return reverse('custom-urls:claim-status', kwargs={'pk': self.id})
+
+
+@receiver(post_save, sender=Claim)
+def notify_matching_offerers(sender, instance, created, **kwargs):
+    # Only notify when the claim is first created
+    if not created:
+        return True
+
+    # TODO: make a nicer HTML email template
+    OFFERER_NOTIFICATION_EMAIL_STRING = """
+    {user} has claimed the payout for {url}.
+
+    codesy.io will pay your offer of {offer} to {user} on {pay_date}.
+
+    To approve or reject this claim, go to:
+    https://{site}{claim_link}
+    """
+    current_site = Site.objects.get_current()
+
+    others_bids = Bid.objects.filter(
+        issue=instance.issue
+    ).exclude(
+        user=instance.claimant
+    )
+
+    for bid in others_bids:
+        send_mail(
+            "[codesy] %(user)s has claimed payout for %(url)s" %
+            (
+                {'user': instance.claimant, 'url': instance.issue.url}
+            ),
+            OFFERER_NOTIFICATION_EMAIL_STRING.format(
+                user=instance.claimant,
+                url=instance.issue.url,
+                offer=bid.offer,
+                pay_date=instance.expires,
+                site=current_site,
+                claim_link=instance.get_absolute_url()
+            ),
+            settings.DEFAULT_FROM_EMAIL,
+            [bid.user.email]
+        )
 
 
 class Vote(models.Model):

--- a/auctions/serializers.py
+++ b/auctions/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Bid, Claim
+from .models import Bid, Claim, Vote
 
 
 class BidSerializer(serializers.ModelSerializer):
@@ -24,4 +24,16 @@ class ClaimSerializer(serializers.ModelSerializer):
     class Meta:
         model = Claim
         fields = ('id', 'issue', 'claimant', 'evidence', 'status')
+        read_only_fields = ('id',)
+
+
+class VoteSerializer(serializers.ModelSerializer):
+    user = serializers.PrimaryKeyRelatedField(
+        read_only=True,
+        default=serializers.CurrentUserDefault()
+    )
+
+    class Meta:
+        model = Vote
+        fields = ('id', 'user', 'claim', 'approved')
         read_only_fields = ('id',)

--- a/auctions/serializers.py
+++ b/auctions/serializers.py
@@ -16,14 +16,14 @@ class BidSerializer(serializers.ModelSerializer):
 
 
 class ClaimSerializer(serializers.ModelSerializer):
-    claimant = serializers.PrimaryKeyRelatedField(
+    user = serializers.PrimaryKeyRelatedField(
         read_only=True,
         default=serializers.CurrentUserDefault()
     )
 
     class Meta:
         model = Claim
-        fields = ('id', 'issue', 'claimant', 'evidence', 'status')
+        fields = ('id', 'issue', 'user', 'evidence', 'status')
         read_only_fields = ('id',)
 
 

--- a/auctions/tests/model_tests.py
+++ b/auctions/tests/model_tests.py
@@ -164,7 +164,7 @@ class NotifyMatchingOfferersTest(MarketTestCase):
         mock_send_mail.is_callable().times_called(3)
         mommy.make(
             Claim,
-            claimant=self.user1,
+            user=self.user1,
             issue=self.issue,
             evidence=self.evidence,
             created=datetime.now()
@@ -181,7 +181,7 @@ class NotifyMatchingOfferersTest(MarketTestCase):
         mock_send_mail.is_callable().times_called(3)
         mommy.make(
             Claim,
-            claimant=self.user1,
+            user=self.user1,
             issue=self.issue,
             evidence=self.evidence,
             created=datetime.now()
@@ -192,7 +192,7 @@ class NotifyMatchingOfferersTest(MarketTestCase):
         mock_send_mail.is_callable().times_called(3)
         claim = mommy.make(
             Claim,
-            claimant=self.user1,
+            user=self.user1,
             issue=self.issue,
             created=datetime.now()
         )

--- a/auctions/tests/model_tests.py
+++ b/auctions/tests/model_tests.py
@@ -8,25 +8,66 @@ from django.test import TestCase
 
 from model_mommy import mommy
 
+from ..models import Bid, Claim, Issue
 
-class NotifyMatchersReceiverTest(TestCase):
+
+class MarketTestCase(TestCase):
     def setUp(self):
         """
         Set up the following market of Bids for a single bug:
+            url: http://github.com/codesy/codesy/issues/37
             user1: ask 50,  offer 0
             user2: ask 100, offer 10
             user3: ask 0,   offer 30
         """
         self.url = 'http://github.com/codesy/codesy/issues/37'
-        self.bid1 = mommy.make('auctions.Bid', user__email='user1@test.com',
+        self.issue = mommy.make(Issue, url=self.url)
+        self.user1 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user1@test.com')
+        self.user2 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user2@test.com')
+        self.user3 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user3@test.com')
+        self.bid1 = mommy.make(Bid, user=self.user1,
                                ask=50, offer=0, url=self.url)
-        self.bid2 = mommy.make('auctions.Bid', user__email='user2@test.com',
+        self.bid2 = mommy.make(Bid, user=self.user2,
                                ask=100, offer=10, url=self.url)
-        self.bid3 = mommy.make('auctions.Bid', user__email='user3@test.com',
+        self.bid3 = mommy.make(Bid, user=self.user3,
                                ask=0, offer=30, url=self.url)
 
     def _add_url(self, string):
         return string.format(url=self.url)
+
+
+class BidTests(MarketTestCase):
+    def test_ask_met(self):
+        self.assertFalse(self.bid1.ask_met())
+        mommy.make(Bid, ask=0, offer=10, url=self.url)
+        self.assertTrue(self.bid1.ask_met())
+
+    def test_ask_met_doesnt_include_bidder(self):
+        self.assertFalse(self.bid1.ask_met())
+        self.bid1.offer = 50
+        self.bid1.save()
+        self.assertFalse(self.bid1.ask_met())
+
+    def test_save_assigns_issue_for_existing_url(self):
+        mommy.make(Bid, ask=200, offer=5, url=self.url)
+        issues = Issue.objects.all()
+        self.assertEquals(1, len(issues))
+        issue = issues[0]
+        self.assertEquals(self.url, issue.url)
+
+    def test_save_creates_issue_for_new_url(self):
+        url = 'https://github.com/codesy/codesy/issues/165'
+        mommy.make(Bid, ask=200, offer=5, url=url)
+        issues = Issue.objects.all()
+        self.assertEquals(2, len(issues))
+        issue = Issue.objects.get(url=url)
+        self.assertEquals(url, issue.url)
+
+
+class NotifyMatchersReceiverTest(MarketTestCase):
 
     @fudge.patch('auctions.models.send_mail')
     def test_dont_email_self_when_offering_more_than_ask(self, mock_send_mail):
@@ -34,7 +75,7 @@ class NotifyMatchersReceiverTest(TestCase):
         user = mommy.make(settings.AUTH_USER_MODEL)
         url = 'https://github.com/codesy/codesy/issues/149'
         offer_bid = mommy.prepare(
-            'auctions.Bid', user=user, url=url, offer=100, ask=10
+            Bid, user=user, url=url, offer=100, ask=10
         )
         offer_bid.save()
 
@@ -56,7 +97,7 @@ class NotifyMatchersReceiverTest(TestCase):
         )
 
         offer_bid = mommy.prepare(
-            'auctions.Bid', offer=100, user=user, ask=1000, url=self.url
+            Bid, offer=100, user=user, ask=1000, url=self.url
         )
         offer_bid.save()
 
@@ -74,7 +115,7 @@ class NotifyMatchersReceiverTest(TestCase):
         )
 
         offer_bid = mommy.prepare(
-            'auctions.Bid', offer=100, user=user, ask=1000, url=self.url
+            Bid, offer=100, user=user, ask=1000, url=self.url
         )
         offer_bid.save()
 
@@ -92,5 +133,55 @@ class NotifyMatchersReceiverTest(TestCase):
         )
 
         mommy.make(
-            'auctions.Bid', offer=100, user=user, ask=1000, url=self.url
+            Bid, offer=100, user=user, ask=1000, url=self.url
         )
+
+
+class NotifyMatchingOfferersTest(MarketTestCase):
+    def setUp(self):
+        """
+        Add a final bid and a user2 claim to the MarketTestCase,
+        so the final market for the bug is now:
+            url: http://github.com/codesy/codesy/issues/37
+            user1: ask 50,  offer 0  (ask is met)
+            user2: ask 100, offer 10
+            user3: ask 0,   offer 30
+            user4: ask 200, offer 10
+        And user1 is making the claim
+        """
+        super(NotifyMatchingOfferersTest, self).setUp()
+        self.user4 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user4@test.com')
+        self.bid4 = mommy.make(Bid, user=self.user4,
+                               ask=200, offer=10, url=self.url)
+        self.evidence = ('https://github.com/codesy/codesy/commit/'
+                         '4f1bcd014ec735918bebd1c386e2f99a7f83ff64')
+
+    @fudge.patch('auctions.models.send_mail')
+    def test_send_email_to_offerers_when_claim_is_made(self,
+                                                       mock_send_mail):
+        # Should be called 3 times: for user2, user3, and user4
+        mock_send_mail.is_callable().times_called(3)
+        mommy.make(
+            Claim,
+            claimant=self.user1,
+            issue=self.issue,
+            evidence=self.evidence,
+            created=datetime.now()
+        )
+
+    @fudge.patch('auctions.models.send_mail')
+    def test_dont_send_email_on_saving_claim(self, mock_send_mail):
+        mock_send_mail.is_callable().times_called(3)
+        claim = mommy.make(
+            Claim,
+            claimant=self.user1,
+            issue=self.issue,
+            created=datetime.now()
+        )
+        claim.status = 'ES'
+        claim.save()
+        claim.status = 'RE'
+        claim.save()
+        claim.status = 'PA'
+        claim.save()

--- a/auctions/tests/model_tests.py
+++ b/auctions/tests/model_tests.py
@@ -158,9 +158,26 @@ class NotifyMatchingOfferersTest(MarketTestCase):
                          '4f1bcd014ec735918bebd1c386e2f99a7f83ff64')
 
     @fudge.patch('auctions.models.send_mail')
-    def test_send_email_to_offerers_when_claim_is_made(self,
-                                                       mock_send_mail):
+    def test_send_email_to_other_offerers_when_claim_is_made(self,
+                                                             mock_send_mail):
         # Should be called 3 times: for user2, user3, and user4
+        mock_send_mail.is_callable().times_called(3)
+        mommy.make(
+            Claim,
+            claimant=self.user1,
+            issue=self.issue,
+            evidence=self.evidence,
+            created=datetime.now()
+        )
+
+    @fudge.patch('auctions.models.send_mail')
+    def test_dont_send_email_to_bidders_who_offered_0(self,
+                                                      mock_send_mail):
+        user5 = mommy.make(settings.AUTH_USER_MODEL,
+                           email='user5@test.com')
+        mommy.make(Bid, user=user5, ask=500, offer=0, url=self.url)
+
+        # Should still be called just 3 times: for user2, user3, and user4
         mock_send_mail.is_callable().times_called(3)
         mommy.make(
             Claim,

--- a/auctions/tests/serializer_tests.py
+++ b/auctions/tests/serializer_tests.py
@@ -29,7 +29,7 @@ class ClaimSerializerTest(TestCase):
             rest_framework.serializers.ModelSerializer)
         self.assertEqual(self.serializer.Meta.model, models.Claim)
         self.assertSequenceEqual(
-            self.serializer.Meta.fields, ('id', 'issue', 'claimant',
+            self.serializer.Meta.fields, ('id', 'issue', 'user',
                                           'evidence', 'status'))
         self.assertSequenceEqual(
             self.serializer.Meta.read_only_fields, ('id',))

--- a/auctions/tests/view_tests.py
+++ b/auctions/tests/view_tests.py
@@ -32,7 +32,7 @@ class BidViewSetTest(TestCase):
 
     def test_attrs(self):
         self.assertIsInstance(
-            self.viewset, rest_framework.viewsets.ModelViewSet)
+            self.viewset, views.AutoOwnObjectsModelViewSet)
         self.assertIsInstance(self.viewset.queryset, QuerySet)
         self.assertEqual(self.viewset.queryset.model, models.Bid)
         self.assertEqual(
@@ -112,7 +112,7 @@ class ClaimViewSetTest(TestCase):
 
     def test_attrs(self):
         self.assertIsInstance(
-            self.viewset, rest_framework.viewsets.ModelViewSet)
+            self.viewset, views.AutoOwnObjectsModelViewSet)
         self.assertIsInstance(self.viewset.queryset, QuerySet)
         self.assertEqual(self.viewset.queryset.model, models.Claim)
         self.assertEqual(
@@ -177,3 +177,16 @@ class ClaimAPIViewTest(TestCase):
         )
 
         self.view.get(self.view.request, 1)
+
+
+class VoteViewSetTest(TestCase):
+    def setUp(self):
+        self.viewset = views.VoteViewSet()
+
+    def test_attrs(self):
+        self.assertIsInstance(
+            self.viewset, views.AutoOwnObjectsModelViewSet)
+        self.assertIsInstance(self.viewset.queryset, QuerySet)
+        self.assertEqual(self.viewset.queryset.model, models.Vote)
+        self.assertEqual(
+            self.viewset.serializer_class, serializers.VoteSerializer)

--- a/auctions/tests/view_tests.py
+++ b/auctions/tests/view_tests.py
@@ -22,7 +22,7 @@ def _make_test_claim():
     user = mommy.make(settings.AUTH_USER_MODEL)
     url = 'http://gh.com/project'
     issue = mommy.make('auctions.Issue', url=url)
-    claim = mommy.make('auctions.Claim', claimant=user, issue=issue)
+    claim = mommy.make('auctions.Claim', user=user, issue=issue)
     return user, url, issue, claim
 
 
@@ -97,7 +97,7 @@ class BidAPIViewTest(TestCase):
     @fudge.patch('auctions.views.Response')
     def test_get_existant_bid_with_claim(self, mock_resp):
         user, url, bid = _make_test_bid()
-        claim = mommy.make('auctions.Claim', issue=bid.issue, claimant=user)
+        claim = mommy.make('auctions.Claim', issue=bid.issue, user=user)
         self.view.request = fudge.Fake().has_attr(
             user=user, query_params={'url': url})
         mock_resp.expects_call().with_args(
@@ -118,18 +118,18 @@ class ClaimViewSetTest(TestCase):
         self.assertEqual(
             self.viewset.serializer_class, serializers.ClaimSerializer)
 
-    def test_pre_save_sets_claimant_to_request_user(self):
+    def test_pre_save_sets_user_to_request_user(self):
         user, url, issue, claim = _make_test_claim()
         self.viewset.request = fudge.Fake().has_attr(user=user)
 
         self.viewset.pre_save(claim)
 
-        self.assertEqual(claim.claimant, user)
+        self.assertEqual(claim.user, user)
 
     def test_get_queryset_filters_by_request_user(self):
         user1, url, issue, claim1 = _make_test_claim()
         user2 = mommy.make(settings.AUTH_USER_MODEL)
-        mommy.make('auctions.Claim', claimant=user2)
+        mommy.make('auctions.Claim', user=user2)
         self.viewset.request = fudge.Fake().has_attr(user=user1)
 
         qs = self.viewset.get_queryset()

--- a/auctions/tests/view_tests.py
+++ b/auctions/tests/view_tests.py
@@ -59,21 +59,6 @@ class BidViewSetTest(TestCase):
 
         self.assertSequenceEqual(qs.order_by('id'), [bid1, bid4, bid5])
 
-    @fudge.test
-    def test_perform_create_creates_Issue(self):
-        url = 'https://github.com/example/project/issue/7'
-        fake_serializer = fudge.Fake("serializers.BidSerializer")
-        (
-            fake_serializer
-            .expects('save')
-            .returns_fake()
-            .has_attr(url=url)
-            .expects('save')
-        )
-        self.viewset.perform_create(fake_serializer)
-        # the Issue should be available
-        models.Issue.objects.get(url=url)
-
 
 class BidAPIViewTest(TestCase):
     def setUp(self):

--- a/auctions/urls.py
+++ b/auctions/urls.py
@@ -9,6 +9,7 @@ router = routers.DefaultRouter()
 router.register(r'bids', views.BidViewSet)
 router.register(r'claims', views.ClaimViewSet)
 router.register(r'issues', views.ClaimViewSet)
+router.register(r'votes', views.VoteViewSet)
 
 custom_endpoint_url_patterns = patterns(
     '',

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
-from .models import Bid, Claim, Issue, Vote
+from .models import Bid, Claim, Vote
 from .serializers import BidSerializer, ClaimSerializer, VoteSerializer
 
 
@@ -21,15 +21,6 @@ class BidViewSet(ModelViewSet):
 
     def get_queryset(self):
         return self.queryset.filter(user=self.request.user)
-
-    def perform_create(self, serializer):
-        bid = serializer.save()
-        issue, created = Issue.objects.get_or_create(
-            url=bid.url,
-            defaults={'state': 'open', 'last_fetched': None}
-        )
-        bid.issue = issue
-        bid.save()
 
 
 class BidAPIView(APIView):

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -45,7 +45,7 @@ class BidAPIView(APIView):
         else:
             try:
                 claim = Claim.objects.get(
-                    claimant=self.request.user, issue=bid.issue
+                    user=self.request.user, issue=bid.issue
                 )
             except Claim.DoesNotExist:
                 pass
@@ -66,10 +66,10 @@ class ClaimViewSet(ModelViewSet):
     renderer_classes = (TemplateHTMLRenderer,)
 
     def pre_save(self, obj):
-        obj.claimant = self.request.user
+        obj.user = self.request.user
 
     def get_queryset(self):
-        return self.queryset.filter(claimant=self.request.user)
+        return self.queryset.filter(user=self.request.user)
 
     def perform_create(self, serializer):
         serializer.save(created=datetime.now())

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -5,8 +5,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
-from .models import Bid, Claim, Issue
-from .serializers import BidSerializer, ClaimSerializer
+from .models import Bid, Claim, Issue, Vote
+from .serializers import BidSerializer, ClaimSerializer, VoteSerializer
 
 
 class BidViewSet(ModelViewSet):
@@ -102,3 +102,21 @@ class ClaimAPIView(APIView):
             claim = None
 
         return Response({'claim': claim}, template_name='claim_status.html')
+
+
+# TODO: Create OwnModelViewSet mix-in
+class VoteViewSet(ModelViewSet):
+    """
+    API endpoint for votes. Users can only access their own votes.
+    """
+    queryset = Vote.objects.all()
+    serializer_class = VoteSerializer
+
+    def pre_save(self, obj):
+        obj.user = self.request.user
+
+    def get_queryset(self):
+        return self.queryset.filter(user=self.request.user)
+
+    def perform_create(self, serializer):
+        serializer.save(created=datetime.now())

--- a/codesy/templates/claim_status.html
+++ b/codesy/templates/claim_status.html
@@ -5,7 +5,7 @@
 
 <a target="_blank" href='{{ claim.issue.url }}'>{{ claim.issue.url }}</a></br>
 
-{%  if claim.claimant == request.user %}
+{%  if claim.user == request.user %}
 
 <a target="_blank" href='{{ claim.evidence }}'>{{ claim.evidence }}</a></br>
 


### PR DESCRIPTION
This adds the base Vote model and a VoteViewSet for default django-rest-framework API endpoints on the model.

Also includes some refactoring and test fixes for other issues that were easy to make here.