### PR TITLE
fix #212, fix #214: move perform_create to models

### DIFF
--- a/auctions/models.py
+++ b/auctions/models.py
@@ -12,6 +12,7 @@ from mailer import send_mail
 
 
 class Bid(models.Model):
+    # TODO: add created and modified fields to auctions.models.Bid
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     url = models.URLField()
     issue = models.ForeignKey('Issue', null=True)
@@ -176,6 +177,7 @@ def notify_matching_offerers(sender, instance, created, **kwargs):
 class Vote(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     claim = models.ForeignKey(Claim)
+    # TODO: Vote.approved needs null=True or blank=False
     approved = models.BooleanField(default=None, blank=True)
     created = models.DateTimeField(null=True, blank=True)
     modified = models.DateTimeField(null=True, blank=True, auto_now=True)
@@ -184,3 +186,12 @@ class Vote(models.Model):
         return u'Vote for %s by (%s): %s' % (
             self.claim, self.user, self.approved
         )
+
+
+@receiver(post_save, sender=Claim)
+@receiver(post_save, sender=Vote)
+def update_datetimes_for_model_save(sender, instance, created, **kwargs):
+    if created:
+        instance.created = datetime.now()
+    else:
+        instance.modified = datetime.now()

--- a/auctions/tests/model_tests.py
+++ b/auctions/tests/model_tests.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import time
 
 import fudge
 from fudge.inspector import arg
@@ -8,7 +9,7 @@ from django.test import TestCase
 
 from model_mommy import mommy
 
-from ..models import Bid, Claim, Issue
+from ..models import Bid, Claim, Issue, Vote
 
 
 class MarketTestCase(TestCase):
@@ -137,6 +138,24 @@ class NotifyMatchersReceiverTest(MarketTestCase):
         )
 
 
+class ClaimTest(TestCase):
+    def test_save_updates_datetimes(self):
+        test_claim = mommy.make(Claim)
+        test_claim_created = test_claim.created
+        self.assertTrue(datetime.now() >= test_claim_created,
+                        "Claim.created should be auto-populated.")
+        time.sleep(1)
+        test_claim.evidence = 'https://test.com/123'
+        test_claim.save()
+        self.assertEqual(test_claim_created, test_claim.created,
+                         "Claim.created should stay the same after an update.")
+        test_claim_modified = test_claim.modified
+        self.assertTrue(test_claim_modified >= test_claim_created,
+                        "Claim.modified should be auto-populated on update.")
+        self.assertTrue(datetime.now() >= test_claim_modified,
+                        "Claim.modified should be auto-populated.")
+
+
 class NotifyMatchingOfferersTest(MarketTestCase):
     def setUp(self):
         """
@@ -202,3 +221,21 @@ class NotifyMatchingOfferersTest(MarketTestCase):
         claim.save()
         claim.status = 'PA'
         claim.save()
+
+
+class VoteTest(TestCase):
+    def test_save_updates_datetimes(self):
+        test_vote = mommy.make(Vote, approved=False)
+        test_vote_created = test_vote.created
+        self.assertTrue(datetime.now() >= test_vote_created,
+                        "Vote.created should be auto-populated.")
+        time.sleep(1)
+        test_vote.approved = True
+        test_vote.save()
+        self.assertEqual(test_vote_created, test_vote.created,
+                         "Vote.created should stay the same after an update.")
+        test_vote_modified = test_vote.modified
+        self.assertTrue(test_vote_modified >= test_vote_created,
+                        "Vote.modified should be auto-populated on update.")
+        self.assertTrue(datetime.now() >= test_vote_modified,
+                        "Vote.modified should be auto-populated.")

--- a/auctions/tests/view_tests.py
+++ b/auctions/tests/view_tests.py
@@ -1,5 +1,4 @@
 import fudge
-from fudge.inspector import arg
 
 from django.conf import settings
 from django.db.models.query import QuerySet
@@ -135,15 +134,6 @@ class ClaimViewSetTest(TestCase):
         qs = self.viewset.get_queryset()
 
         self.assertSequenceEqual(qs.order_by('id'), [claim1, ])
-
-    @fudge.test
-    def test_perform_create_saves_created_datetime(self):
-        fake_serializer = (
-            fudge.Fake('serializers.ClaimSerializer')
-            .expects('save')
-            .with_args(created=arg.any())
-        )
-        self.viewset.perform_create(fake_serializer)
 
 
 class ClaimAPIViewTest(TestCase):

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from rest_framework.renderers import TemplateHTMLRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -72,10 +70,6 @@ class ClaimViewSet(AutoOwnObjectsModelViewSet):
     serializer_class = ClaimSerializer
     renderer_classes = (TemplateHTMLRenderer,)
 
-    # TODO: move ClaimViewSet.perform_create to model pre_save signal handler
-    def perform_create(self, serializer):
-        serializer.save(created=datetime.now())
-
 
 class ClaimAPIView(APIView):
     """
@@ -103,7 +97,3 @@ class VoteViewSet(AutoOwnObjectsModelViewSet):
     """
     queryset = Vote.objects.all()
     serializer_class = VoteSerializer
-
-    # TODO: move VoteViewSet.perform_create to a model pre_save signal handler
-    def perform_create(self, serializer):
-        serializer.save(created=datetime.now())


### PR DESCRIPTION
Move the logic to automatically populate created and modified fields from DRF
viewset hooks into model signals.