### PR TITLE
add cffi to requirements.txt so heroku uses libffi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,6 @@ requests==2.9.1
 requests-oauthlib==0.6.1
 static==1.1.1
 wsgiref==0.1.2
-stripe==1.31.1
+cffi==1.5.2
+stripe==1.32.2
 paypalrestsdk==1.11.5


### PR DESCRIPTION
@jezdez fixed me up ... if you explicitly include `cffi` in `requirements.txt` the default heroku-buildpack-python detects it and bootstraps libffi for the build.

https://github.com/heroku/heroku-buildpack-python/blob/eab957c8c96acf1689ca98368a23940f2fe00e97/bin/steps/cryptography#L22-L35

This fixed the heroku build step. On to a `python manage.py migrate` problem next ...