### PR TITLE
fix #277: add voted claims to claim list template

### DIFF
--- a/api/templates/claim_list.html
+++ b/api/templates/claim_list.html
@@ -15,6 +15,20 @@
             </div>
         </div>
     {% endfor %}
+
+    <div class="row medium-8 large-7 columns">
+        <h3>You have voted on these claims:</h3>
+    </div>
+    {% for claim in voted_claims %}
+        <div class="row medium-8 large-7 columns">
+            <div class="callout primary">
+                <h3><a href="{{claim.issue.url}}">{{claim.issue.title}}</a></h3>
+                <a href="//{{current_site.domain}}{% url 'custom-urls:claim-status' pk=claim.id %}">
+                    Check on the status
+                </a>
+            </div>
+        </div>
+    {% endfor %}
 {% endblock %}
 
 {% block scripts %}

--- a/api/views.py
+++ b/api/views.py
@@ -147,10 +147,12 @@ class ClaimList(APIView):
     def get(self, request, format=None):
         try:
             claims = Claim.objects.filter(user=self.request.user)
+            voted_claims = Claim.objects.voted_on_by_user(self.request.user)
         except:
             claims = []
 
-        return Response({'claims': claims}, template_name='claim_list.html')
+        return Response({'claims': claims, 'voted_claims': voted_claims},
+                        template_name='claim_list.html')
 
 
 class VoteList(APIView):

--- a/auctions/managers.py
+++ b/auctions/managers.py
@@ -1,0 +1,8 @@
+from django.db import models
+
+
+class ClaimManager(models.Manager):
+    def voted_on_by_user(self, user):
+        return super(ClaimManager, self).get_queryset().filter(
+            vote__user=user
+        )

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -18,6 +18,8 @@ from django.dispatch import receiver
 from decimal import Decimal, ROUND_UP
 from mailer import send_mail
 
+from .managers import ClaimManager
+
 stripe.api_key = settings.STRIPE_SECRET_KEY
 
 # TODO: Find a prettier way to authenticate
@@ -207,6 +209,8 @@ class Claim(models.Model):
     status = models.CharField(max_length=255,
                               choices=STATUS_CHOICES,
                               default='Submitted')
+
+    objects = ClaimManager()
 
     class Meta:
         unique_together = (("user", "issue"),)

--- a/auctions/tests/__init__.py
+++ b/auctions/tests/__init__.py
@@ -1,0 +1,60 @@
+from model_mommy import mommy
+
+from django.conf import settings
+from django.test import TestCase
+
+from ..models import Bid, Claim, Issue
+
+
+class MarketWithBidsTestCase(TestCase):
+    def setUp(self):
+        """
+        Set up the following market of Bids for a single bug:
+            url: http://github.com/codesy/codesy/issues/37
+            user1: ask 50,  offer 0
+            user2: ask 100, offer 10
+            user3: ask 0,   offer 30
+        """
+        self.url = 'http://github.com/codesy/codesy/issues/37'
+        self.issue = mommy.make(Issue, url=self.url)
+        self.user1 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user1@test.com')
+        self.user2 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user2@test.com')
+        self.user3 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user3@test.com')
+        self.bid1 = mommy.make(Bid, user=self.user1,
+                               ask=50, offer=0, url=self.url)
+        self.bid2 = mommy.make(Bid, user=self.user2,
+                               ask=100, offer=10, url=self.url)
+        self.bid3 = mommy.make(Bid, user=self.user3,
+                               ask=0, offer=30, url=self.url)
+
+    def _add_url(self, string):
+        return string.format(url=self.url)
+
+
+class MarketWithClaimTestCase(TestCase):
+    def setUp(self):
+        """
+        Set up the following claim senarios
+            user1: asks 50
+            user2: offers 25
+            user3: offers 25
+        """
+        self.url = 'http://github.com/codesy/codesy/issues/37'
+        self.issue = mommy.make(Issue, url=self.url)
+
+        self.user1 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user1@test.com')
+        self.user2 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user2@test.com')
+        self.user3 = mommy.make(settings.AUTH_USER_MODEL,
+                                email='user3@test.com')
+        self.bid1 = mommy.make(Bid, user=self.user1,
+                               ask=50, offer=0, url=self.url)
+        self.bid2 = mommy.make(Bid, user=self.user2,
+                               ask=0, offer=25, url=self.url)
+        self.bid3 = mommy.make(Bid, user=self.user3,
+                               ask=0, offer=25, url=self.url)
+        self.claim = mommy.make(Claim, user=self.user1, issue=self.issue)

--- a/auctions/tests/managers_tests.py
+++ b/auctions/tests/managers_tests.py
@@ -1,0 +1,14 @@
+from model_mommy import mommy
+
+from ..models import Vote, Claim
+
+from . import MarketWithClaimTestCase
+
+
+class ClaimManagerTestCase(MarketWithClaimTestCase):
+    def test_voted_on_by_user_returns_claims(self):
+        mommy.make(Vote, user=self.user2, claim=self.claim, approved=True)
+        claims = Claim.objects.voted_on_by_user(self.user2)
+        self.assertEqual(1, len(claims))
+        for claim in claims:
+            self.assertEqual(self.claim, claim)


### PR DESCRIPTION
Introduces a new `ClaimManager` class with a `voted_on_by_user` convenience method. Also refactors some `MarketTestCase` `setUp` into the `tests` module to make them more re-usable.