### PR TITLE
Payment offer testing

### DIFF
--- a/auctions/templates/addon/register_card.html
+++ b/auctions/templates/addon/register_card.html
@@ -1,0 +1,13 @@
+{% extends "addon/base.html" %}
+{% load socialaccount %}
+{% load staticfiles %}
+
+{% block widget_content %}
+    Thanks for installing the codesy addon. You need to register a credit card to start bidding.
+
+    <a class="button success expanded"
+    href="{% url 'card' %}"
+    target="_blank">
+    Save a Credit Card &raquo;</a>
+
+{% endblock %}

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -23,7 +23,11 @@ class BidStatusView(UserPassesTestMixin, LoginRequiredMixin, TemplateView):
     template_name = "addon/bidders.html"
 
     def test_func(self):
-        return self.request.user.is_active
+        if self.request.user.is_active:
+            if not self.request.user.stripe_customer:
+                self.template_name = "addon/register_card.html"
+            return True
+        return False
 
     def _get_bid(self, url):
         try:

--- a/payments/templates/credit_card_page.html
+++ b/payments/templates/credit_card_page.html
@@ -2,7 +2,7 @@
 {% block content %}
     <div class="row">
         <div class="column medium-4 medium-offset-4 text-left">
-            {% if request.user.stripe_bank_account %}
+            {% if request.user.stripe_customer %}
                 You have already registered a credit card with us.  You can use this form to change the card information.
             {% else %}
                 To make offers, you need to register a credit card.  This information is not stored in codesy's database.

--- a/payments/templates/credit_card_page.html
+++ b/payments/templates/credit_card_page.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="column medium-4 medium-offset-4 text-left">
             {% if request.user.stripe_customer %}
-                You have already registered a credit card with us.  You can use this form to change the card information.
+                You have a credit card registered with us.  You can use this form to change the card information.
             {% else %}
                 To make offers, you need to register a credit card.  This information is not stored in codesy's database.
             {% endif %}

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -115,7 +115,6 @@ def authorize(offer):
 def charge(offer, payout):
     details = transaction_amounts(payout.amount)
 
-    import ipdb; ipdb.set_trace()
     try:
         charge = stripe.Charge.create(
             customer=offer.user.stripe_customer,
@@ -131,6 +130,11 @@ def charge(offer, payout):
             payout.charge_id = charge.id
             payout.api_success = True
             payout.save()
+
+            offer.api_success = True
+            offer.charge_id = charge.id
+            offer.save()
+
             payout.claim.status = 'Paid'
             payout.claim.save()
         else:

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -115,10 +115,11 @@ def authorize(offer):
 def charge(offer, payout):
     details = transaction_amounts(payout.amount)
 
+    import ipdb; ipdb.set_trace()
     try:
         charge = stripe.Charge.create(
             customer=offer.user.stripe_customer,
-            destination=payout.user.account().account_id,
+            destination=payout.claim.user.account().account_id,
             amount=int(details['charge_amount'] * 100),
             currency="usd",
             description="Payout for: " + offer.bid.url,

--- a/static/js/widget-app.js
+++ b/static/js/widget-app.js
@@ -46,6 +46,7 @@ labelDiff = function(type, $from_elem, $to_elem){
         } else if (diff > 0 ) {
             confirmTemplate = ["Your offer increased. $",diff," will be authorized your credit card."]
         } else if (diff < 0) {
+            $('#submitForm').hide()
             confirmTemplate = ["Sorry, you can't decrease your offer."]
             $from_elem.val(original_value)
         }


### PR DESCRIPTION
Tweaks to:

1) payment needs to use claimant's bank not offerer's
2) add charge id to offer when successfully paid
3) redirect user to cc form if cc token not saved
4) don't let widget submit a lowered offer
