### PR TITLE
fix #423: add success message when saving cc and bank info

### DIFF
--- a/payments/templates/bank_account_form.html
+++ b/payments/templates/bank_account_form.html
@@ -23,7 +23,7 @@
         </div>
         <button id="stripe-submit" class="button success track-btn"
                 data-category="Stripe" data-label="Authorize">
-                Encrypt Bank Account Information
+                Encrypt Account Information
         </button>
     </form>
 </fieldset>

--- a/payments/templates/bank_account_form.html
+++ b/payments/templates/bank_account_form.html
@@ -23,7 +23,7 @@
         </div>
         <button id="stripe-submit" class="button success track-btn"
                 data-category="Stripe" data-label="Authorize">
-                Encrypt Account Information
+                Tokenize Account Information
         </button>
     </form>
 </fieldset>

--- a/payments/templates/bank_account_page.html
+++ b/payments/templates/bank_account_page.html
@@ -5,8 +5,9 @@
             {% if request.user.stripe_bank_account %}
                 You have already registered a bank acount with us.  You can use this form to change the account.
             {% else %}
-                To receive payouts, you need to register a bank account.  This information is not stored in codesy's database.
+                To receive payouts, you need to register a bank account.
             {% endif %}
+                We tokenize this information with Stripe so it is not stored in codesy's database.
             {% include "bank_account_form.html" %}
         </div>
     </div>

--- a/payments/templates/credit_card_form.html
+++ b/payments/templates/credit_card_form.html
@@ -10,6 +10,6 @@
         <input type="text" class="form-control" data-stripe="exp_year" autocomplete="off" value="{{ STRIPE_DEBUG.card.cc_ex_year}}" maxlength="4" size="4"/>
         <label for="cvc">Card Verification Code (CVC)</label>
         <input type="text" class="form-control" data-stripe="cvc" autocomplete="off" value="{{ STRIPE_DEBUG.card.cvc}}" maxlength="4" size="4"/>
-        <button id="stripe-submit" class="button success track-btn" data-category="Stripe" data-label="Authorize">Encrypt Account Information</button>
+        <button id="stripe-submit" class="button success track-btn" data-category="Stripe" data-label="Authorize">Tokenize Account Information</button>
     </form>
 </fieldset>

--- a/payments/templates/credit_card_form.html
+++ b/payments/templates/credit_card_form.html
@@ -10,6 +10,6 @@
         <input type="text" class="form-control" data-stripe="exp_year" autocomplete="off" value="{{ STRIPE_DEBUG.card.cc_ex_year}}" maxlength="4" size="4"/>
         <label for="cvc">Card Verification Code (CVC)</label>
         <input type="text" class="form-control" data-stripe="cvc" autocomplete="off" value="{{ STRIPE_DEBUG.card.cvc}}" maxlength="4" size="4"/>
-        <button id="stripe-submit" class="button success track-btn" data-category="Stripe" data-label="Authorize">Encrypt Credit Card Information</button>
+        <button id="stripe-submit" class="button success track-btn" data-category="Stripe" data-label="Authorize">Encrypt Account Information</button>
     </form>
 </fieldset>

--- a/payments/templates/credit_card_page.html
+++ b/payments/templates/credit_card_page.html
@@ -5,8 +5,9 @@
             {% if request.user.stripe_customer %}
                 You have a credit card registered with us.  You can use this form to change the card information.
             {% else %}
-                To make offers, you need to register a credit card.  This information is not stored in codesy's database.
+                To make offers, you need to register a credit card.
             {% endif %}
+                We tokenize this information with Stripe so it is not stored in codesy's database.
             {% include "credit_card_form.html" %}
         </div>
     </div>

--- a/static/js/stripe-app.js
+++ b/static/js/stripe-app.js
@@ -1,14 +1,16 @@
 $(window).load(function () {
     Stripe.setPublishableKey($('#codesy-html').data('stripe_key'));
     function response_div(message){
-        return `
+        $div= $(`
             <div class="callout warning expanded" data-closable>
                 <button class="close-button" data-close>&times;</button>
                 <p class="alert alert-error">
-                    ${message}
                 </p>
-            </div>`
+            </div>`)
+        $div.find('p').text(message)
+        return $div
     }
+
     let stripeResponse = function (csrf_token) {
         this.csrf_token = csrf_token
         return (function(_this){
@@ -34,6 +36,7 @@ $(window).load(function () {
                         }
                     });
                 }
+
                 $('#stripe-form').prepend(response_div(response_message))
                 $('#stripe-submit').text('Tokenize Account Information');
             }

--- a/static/js/stripe-app.js
+++ b/static/js/stripe-app.js
@@ -26,7 +26,7 @@ $(window).load(function () {
                     });
                 }
                 $('#stripe-form').prepend(message_array.join(""))
-                $('#stripe-submit').text('Encrypt Account Information');
+                $('#stripe-submit').text('Tokenize Account Information');
             }
         })(this)
     }
@@ -48,7 +48,7 @@ $(window).load(function () {
         if (holder_type) {
             $('#account_holder_type').val(holder_type)
         }
-        $('#stripe-submit').text('Encrypting ... ');
+        $('#stripe-submit').text('Tokenizing ... ');
         Stripe[account_type].createToken($form, handleResponse);
     });
 

--- a/static/js/stripe-app.js
+++ b/static/js/stripe-app.js
@@ -1,14 +1,23 @@
 $(window).load(function () {
     Stripe.setPublishableKey($('#codesy-html').data('stripe_key'));
+    function response_div(message){
+        return `
+            <div class="callout warning expanded" data-closable>
+                <button class="close-button" data-close>&times;</button>
+                <p class="alert alert-error">
+                    ${message}
+                </p>
+            </div>`
+    }
     let stripeResponse = function (csrf_token) {
         this.csrf_token = csrf_token
         return (function(_this){
             return function (status, response) {
                 if (response.error) {
                     console.error("Stripe failed to tokenize");
-                    message_array[3] = response.error.message
+                    response_message = response.error.message
                 } else {
-                    message_array[3] = "Account Information successfully encrypted"
+                    response_message = "Account information successfully tokenized"
                     $.ajax({
                         method: "PATCH",
                         url: "/users/update/",
@@ -25,7 +34,7 @@ $(window).load(function () {
                         }
                     });
                 }
-                $('#stripe-form').prepend(message_array.join(""))
+                $('#stripe-form').prepend(response_div(response_message))
                 $('#stripe-submit').text('Tokenize Account Information');
             }
         })(this)
@@ -34,15 +43,9 @@ $(window).load(function () {
     let handleResponse = new stripeResponse($('form input[name="csrfmiddlewaretoken"]').val())
     let $form = $('#stripe-form')
     let account_type = $form.attr('stripe-account-type')
-    let message_array = ['<div class="callout warning expanded" data-closable>',
-        '<button class="close-button" data-close>&times;</button>',
-        '<p class="alert alert-error">',
-        'MESSSAGE GOES IN POS 3',
-        '</p></div>']
 
     $('#stripe-submit').click(function (e) {
         e.preventDefault();
-
         // add account_holder_type for bank account and identity forms
         let holder_type = $("input[name=form_holder_type]:checked").val()
         if (holder_type) {

--- a/static/js/stripe-app.js
+++ b/static/js/stripe-app.js
@@ -6,14 +6,9 @@ $(window).load(function () {
             return function (status, response) {
                 if (response.error) {
                     console.error("Stripe failed to tokenize");
-                    $('#stripe-form').prepend(
-                      '<div class="callout warning expanded" data-closable>' +
-                        '<button class="close-button" data-close>&times;</button>' +
-                        '<p class="alert alert-error">' + response.error.message + '</p>' +
-                      '</div>'
-                    )
-                    $('#stripe-submit').text('Ecrypt Credit Card Information');
+                    message_array[3] = response.error.message
                 } else {
+                    message_array[3] = "Account Information successfully encrypted"
                     $.ajax({
                         method: "PATCH",
                         url: "/users/update/",
@@ -27,12 +22,11 @@ $(window).load(function () {
                         error: function(err) {
                             console.error("Error updating user.");
                             console.error(err);
-                        },
-                        complete: function(){
-                            document.location.reload();
                         }
                     });
                 }
+                $('#stripe-form').prepend(message_array.join(""))
+                $('#stripe-submit').text('Encrypt Account Information');
             }
         })(this)
     }
@@ -40,6 +34,11 @@ $(window).load(function () {
     let handleResponse = new stripeResponse($('form input[name="csrfmiddlewaretoken"]').val())
     let $form = $('#stripe-form')
     let account_type = $form.attr('stripe-account-type')
+    let message_array = ['<div class="callout warning expanded" data-closable>',
+        '<button class="close-button" data-close>&times;</button>',
+        '<p class="alert alert-error">',
+        'MESSSAGE GOES IN POS 3',
+        '</p></div>']
 
     $('#stripe-submit').click(function (e) {
         e.preventDefault();


### PR DESCRIPTION
Had to update the bank account template because stripe-app js is used for stripe forms.