### PR TITLE
simplify payout details fix #484

### DIFF
--- a/auctions/models.py
+++ b/auctions/models.py
@@ -284,6 +284,24 @@ class Claim(models.Model):
     def successful_payouts(self):
         return Payout.objects.filter(claim=self, api_success=True)
 
+    @property
+    def sum_payouts(self):
+        return (
+            self.successful_payouts()
+            .aggregate(Sum('charge_amount'))['charge_amount__sum'])
+
+    @property
+    def sum_fees(self):
+        sum_of = 0
+        for payout in self.successful_payouts():
+            sum_of += payout.sum_fees
+        return sum_of
+
+    @property
+    def sum_credits(self):
+        # these are the claim credits not payout credits!
+        return self.sum_payouts - self.ask + self.sum_fees
+
     def votes_by_approval(self, approved):
         return (Vote.objects
                     .filter(claim=self, approved=approved)
@@ -554,7 +572,7 @@ class Payout(Payment):
         default='Stripe')
 
     def __unicode__(self):
-        return u'Payout to %s for claim (%s)' % (
+        return u'Payout by %s for claim (%s)' % (
             self.user, self.claim.id
         )
 
@@ -567,6 +585,20 @@ class Payout(Payment):
 
     def credits(self):
         return PayoutCredit.objects.filter(payout=self)
+
+    @property
+    def sum_fees(self):
+        sum_of = 0
+        for fee in self.fees():
+            sum_of += fee.amount
+        return sum_of
+
+    @property
+    def sum_credits(self):
+        sum_of = 0
+        for fee in self.credits():
+            sum_of += fee.amount
+        return sum_of
 
     def add_fees(self):
         fee_details = payments.transaction_amounts(self.amount)

--- a/auctions/models.py
+++ b/auctions/models.py
@@ -596,8 +596,8 @@ class Payout(Payment):
     @property
     def sum_credits(self):
         sum_of = 0
-        for fee in self.credits():
-            sum_of += fee.amount
+        for credit in self.credits():
+            sum_of += credit.amount
         return sum_of
 
     def add_fees(self):

--- a/auctions/templates/bid_list.html
+++ b/auctions/templates/bid_list.html
@@ -31,11 +31,10 @@
                         <table>
                             <tr><td>Offer</td><td>{{ bid.last_offer.net_offer }}</td></tr>
                             {% if bid.last_offer.discount %}
-                                <tr><td>surplus</td><td>({{ bid.last_offer.discount }})</td></tr>
+                                <tr><td>Credits</td><td>({{ bid.last_offer.discount }})</td></tr>
+                                <tr><td>Fees</td><td>{{ bid.last_offer.sum_fees }}</td></tr>
+
                             {% endif %}
-                            {% for fee in bid.last_offer.fees %}
-                                <tr><td>{{ fee.fee_type }}</td><td>{{ fee.amount }}</td></tr>
-                            {% endfor %}
                             <tr class="total"><td>Total</td><td>{{ bid.last_offer.charge_amount }}</td></tr>
                         </table>
 

--- a/auctions/templates/bid_list.html
+++ b/auctions/templates/bid_list.html
@@ -31,11 +31,18 @@
                         <table>
                             <tr><td>Offer</td><td>{{ bid.last_offer.net_offer }}</td></tr>
                             {% if bid.last_offer.discount %}
-                                <tr><td>Credits</td><td>({{ bid.last_offer.discount }})</td></tr>
-                                <tr><td>Fees</td><td>{{ bid.last_offer.sum_fees }}</td></tr>
+                                <tr>
+                                    <td>Credits<td>({{ bid.last_offer.discount }})</td>
+                                </tr>
+                                <tr>
+                                    <td>Fees</td><td>{{ bid.last_offer.sum_fees }}</td>
+                                </tr>
 
                             {% endif %}
                             <tr class="total"><td>Total</td><td>{{ bid.last_offer.charge_amount }}</td></tr>
+                            <tr>
+                                <a href="#"><i class="fi-question">Any questions?</i></a></td>
+                            </tr>
                         </table>
 
                     {% endif %}

--- a/auctions/templates/claim_list.html
+++ b/auctions/templates/claim_list.html
@@ -20,7 +20,7 @@
                 <tr>
                     <td><span data-tooltip aria-haspopup="true" class="has-tip" data-disable-hover="false" title="{{ claim.created|date:"r" }}">{{ claim.created|date:"M j" }}</span></td>
                     <td><a href="{% url 'claim-status' claim.id %}">{{claim.issue.title}}</a></td>
-                    <td>{% for payout in claim.payouts.all %}{{ payout.charge_amount }}{% endfor %}</td>
+                    <td>{{ claim.sum_payouts }}</td>
                     <td>{{ claim.status }}</td>
                 </tr>
             {% endfor %}

--- a/auctions/templates/includes/payout.html
+++ b/auctions/templates/includes/payout.html
@@ -26,9 +26,9 @@
             <table>
               <tbody>
                 <tr><td>Ask</td><td>{{ claim.ask  }}</td></tr>
-                <tr><td>Credits </td><td>{{ payout_totals.credits }}</td></tr>
-                <tr><td>Fees</td><td>({{ payout_totals.fees }})</td></tr>
-                <tr><td>Final payout</td><td>{{ payout_totals.final_payout }}</td></tr>
+                <tr><td>Credits </td><td>{{ claim.sum_credits }}</td></tr>
+                <tr><td>Fees</td><td>({{ claim.sum_fees }})</td></tr>
+                <tr><td>Final payout</td><td>{{ claim.sum_payouts }}</td></tr>
               </tbody>
             </table>
           </div>

--- a/auctions/templates/includes/payout.html
+++ b/auctions/templates/includes/payout.html
@@ -21,32 +21,18 @@
        {% endif %}
 
     {% elif claim.status == "Paid" %}
-      {% for payout in claim.successful_payouts.all %}
         <div class="payout row">
-          <div class="medium-6 columns">
-            <dl>
-              <dt>Provider</dt>
-              <dd>{{ payout.provider }}</dd>
-              <dt>Transaction ID</dt>
-              <dd>{{ payout.transaction_key }}</dd>
-            </dl>
-          </div>
           <div class="medium-6 columns">
             <table>
               <tbody>
-                <tr><td>Ask</td><td>{{ payout.less_discount  }}</td></tr>
-                {% for credit in payout.credits %}
-                  <tr><td>{{ credit.fee_type }}</td><td>{{ credit.amount }}</td></tr>
-                {% endfor %}
-                {% for fee in payout.fees %}
-                  <tr><td>{{ fee.fee_type }}</td><td>({{ fee.amount }})</td></tr>
-                {% endfor %}
-                <tr><td>Final payout</td><td>{{ payout.charge_amount }}</td></tr>
+                <tr><td>Ask</td><td>{{ claim.ask  }}</td></tr>
+                <tr><td>Credits </td><td>{{ payout_totals.credits }}</td></tr>
+                <tr><td>Fees</td><td>({{ payout_totals.fees }})</td></tr>
+                <tr><td>Final payout</td><td>{{ payout_totals.final_payout }}</td></tr>
               </tbody>
             </table>
           </div>
         </div>
-      {% endfor %}
 
     {% elif claim.status == "Requested" %}
        <h3>Payout for your claim is on the way</h3>

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -110,7 +110,6 @@ class ClaimStatusView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         claim = None
         vote = None
-        payout_totals = {'fees': 0, 'credits': 0, 'final_payout': 0}
         claim = get_object_or_404(Claim, pk=self.kwargs['pk'])
         try:
             vote = Vote.objects.get(claim=claim, user=self.request.user)

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -113,20 +113,12 @@ class ClaimStatusView(LoginRequiredMixin, TemplateView):
         payout_totals = {'fees': 0, 'credits': 0, 'final_payout': 0}
         claim = get_object_or_404(Claim, pk=self.kwargs['pk'])
         try:
-            for payout in claim.successful_payouts().all():
-                for credit in payout.credits():
-                    payout_totals['credits'] += payout.amount
-                for fee in payout.fees():
-                    payout_totals['fees'] += fee.amount
-                payout_totals['final_payout'] += payout.charge_amount
-
             vote = Vote.objects.get(claim=claim, user=self.request.user)
         except:
             pass
         context = dict({
             'claim': claim,
             'vote': vote,
-            'payout_totals': payout_totals
         })
         return context
 


### PR DESCRIPTION
Consolidated Credit and Fees instead of showing each one.

Steps To Reproduce:
1. user1 asks 100
2. user2 offers 70
3. user3 offers 30
4. user1 claims, is approved, and gets paid

Expected results:
On the claim page, user1 should only see a summary of all the fees and transactions involved in their payout.

Actual results:
On the claim page, user1 sees every individual transaction and its fees involved in their payout.