### PR TITLE
add return url to views and forms fix #488, fix #463

### DIFF
--- a/auctions/templates/includes/payout.html
+++ b/auctions/templates/includes/payout.html
@@ -15,8 +15,7 @@
        {% else %}
 
            <h3>You need to tell us where to send your payout.</h3>
-
-           <li><a class="success button expanded" href="{% url 'bank' %}">Register a bank account</a></li>
+           <li><a class="success button expanded" href="{% url 'bank' %}?return_url={{ return_url }}">Register a bank account</a></li>
 
        {% endif %}
 

--- a/auctions/tests/view_tests.py
+++ b/auctions/tests/view_tests.py
@@ -143,14 +143,14 @@ class ClaimStatusTestCase(TestCase):
 
     def test_get_by_id_returns_context(self):
         self.view.request = (fudge.Fake()
-                             .has_attr(user=self.user1))
+                             .has_attr(user=self.user1, path=""))
         self.view.kwargs = {'pk': self.claim.id}
         context = self.view.get_context_data()
         self.assertEqual(self.claim, context['claim'])
 
     def test_get_by_non_claimaint_returns_context(self):
         self.view.request = (fudge.Fake()
-                             .has_attr(user=self.user2))
+                             .has_attr(user=self.user2, path=""))
         self.view.kwargs = {'pk': self.claim.id}
         context = self.view.get_context_data()
         self.assertEqual(self.claim, context['claim'])

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -127,6 +127,7 @@ class ClaimStatusView(LoginRequiredMixin, TemplateView):
         except:
             pass
         context = dict({
+            'return_url' : self.request.path,
             'claim': claim,
             'vote': vote,
             'aggregate_payout': total_payout

--- a/auctions/views.py
+++ b/auctions/views.py
@@ -127,7 +127,7 @@ class ClaimStatusView(LoginRequiredMixin, TemplateView):
         except:
             pass
         context = dict({
-            'return_url' : self.request.path,
+            'return_url': self.request.path,
             'claim': claim,
             'vote': vote,
             'aggregate_payout': total_payout

--- a/payments/templates/accept_terms.html
+++ b/payments/templates/accept_terms.html
@@ -18,7 +18,7 @@
             method="POST">
             {% csrf_token %}
             {%if return_url %}
-                <input type="hidden" id="return_url" value="{{return_url}}">
+                <input type="hidden" name="return_url" value="{{return_url}}">
             {% endif %}
             <button
                 class="button success track-btn"

--- a/payments/templates/accept_terms.html
+++ b/payments/templates/accept_terms.html
@@ -17,7 +17,9 @@
             action="{% url 'terms' %}"
             method="POST">
             {% csrf_token %}
-
+            {%if return_url %}
+                <input type="hidden" id="return_url" value="{{return_url}}">
+            {% endif %}
             <button
                 class="button success track-btn"
                 data-category="Stripe"

--- a/payments/templates/bank_account_form.html
+++ b/payments/templates/bank_account_form.html
@@ -2,6 +2,9 @@
     <legend>Bank Account Information</legend>
     <form id="stripe-form" stripe-account-type="bankAccount" role="form" class="form-horizontal">
         {% csrf_token %}
+        {%if return_url %}
+            <input type="hidden" id="return_url" value="{{return_url}}">
+        {% endif %}
         <input type="hidden" data-stripe="country" value="US">
         <input type="hidden" data-stripe="currency" value="USD">
         <input type="hidden" id="account_holder_type" data-stripe="account_holder_type" value="individual">

--- a/payments/templates/verify_identity.html
+++ b/payments/templates/verify_identity.html
@@ -18,7 +18,9 @@
             action="/payments/identity"
             method="POST">
             {% csrf_token %}
-
+            {%if return_url %}
+                <input type="hidden" id="return_url" value="{{return_url}}">
+            {% endif %}
             {% if 'legal_entity.first_name' in fields_needed %}
                 <label for="first_name">First Name</label>
                 <input name="first_name" type="text" class="form-control" autocomplete="off" maxlength="16" value="{{ STRIPE_DEBUG.identity.first_name}}"/>

--- a/payments/views.py
+++ b/payments/views.py
@@ -101,7 +101,7 @@ class BankAccountView(BankAccountTestsMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super(BankAccountView, self).get_context_data(**kwargs)
-        ctx['return_url'] = self.request.GET.get('return_url','')
+        ctx['return_url'] = self.request.GET.get('return_url', '')
         ctx['STRIPE_DEBUG'] = stripe_debug_values()
         return ctx
 
@@ -164,8 +164,6 @@ class VerifyIdentityView(TemplateView):
                     stripe_acct.legal_entity.dob[field] = posted[field]
 
             stripe_acct.save()
-
-
 
         return redirect('bank')
 

--- a/payments/views.py
+++ b/payments/views.py
@@ -109,6 +109,11 @@ class BankAccountView(BankAccountTestsMixin, TemplateView):
 class AcceptTermsView(TemplateView):
     template_name = "accept_terms.html"
 
+    def get_context_data(self, **kwargs):
+        ctx = super(AcceptTermsView, self).get_context_data(**kwargs)
+        ctx['return_url'] = self.request.GET.get('return_url', '')
+        return ctx
+
     def get_client_ip(self, request):
         x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
         if x_forwarded_for:
@@ -125,7 +130,10 @@ class AcceptTermsView(TemplateView):
             user.save()
         except User.DoesNotExist:
             pass
-        return redirect('bank')
+            
+        redirect_url = posted['return_url'] or 'bank'
+
+        return redirect(redirect_url)
 
 
 class VerifyIdentityView(TemplateView):
@@ -139,6 +147,7 @@ class VerifyIdentityView(TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super(VerifyIdentityView, self).get_context_data(**kwargs)
         ctx['STRIPE_DEBUG'] = stripe_debug_values()
+        ctx['return_url'] = self.request.GET.get('return_url', '')
         codesy_account = self.request.user.account()
         ctx['fields_needed'] = codesy_account.fields_needed
         return ctx
@@ -165,7 +174,9 @@ class VerifyIdentityView(TemplateView):
 
             stripe_acct.save()
 
-        return redirect('bank')
+        redirect_url = posted['return_url'] or 'bank'
+
+        return redirect(redirect_url)
 
 
 class StripeHookView(CSRFExemptMixin, View):

--- a/payments/views.py
+++ b/payments/views.py
@@ -1,3 +1,5 @@
+import urllib
+
 from django.views.generic import View, TemplateView
 from django.shortcuts import redirect
 from django.core.urlresolvers import reverse_lazy
@@ -70,7 +72,7 @@ class BankAccountTestsMixin(UserPassesTestMixin):
     redirect_field_name = None
 
     def test_func(self):
-        # settting the login_url determnes redirect if test returns false
+        # settting the login_url determines redirect if test returns false
         if self.request.user.accepted_terms():
             self.login_url = self.reverse_lazy_with_param('identity')
         else:
@@ -94,9 +96,8 @@ class CodesyRedirectView(TemplateView):
 
     def reverse_lazy_with_param(self, template_name):
         request_dict = self.request.GET or self.request.POST
-        return_url = request_dict.get('return_url', '')
-        return_param = '?return_url=' + return_url
-        return reverse_lazy(template_name) + return_param
+        return_param = urllib.urlencode(request_dict)
+        return '%s?%s' % (reverse_lazy(template_name), return_param)
 
     def get_context_data(self, **kwargs):
         ctx = super(TemplateView, self).get_context_data(**kwargs)

--- a/payments/views.py
+++ b/payments/views.py
@@ -101,6 +101,7 @@ class BankAccountView(BankAccountTestsMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super(BankAccountView, self).get_context_data(**kwargs)
+        ctx['return_url'] = self.request.GET.get('return_url','')
         ctx['STRIPE_DEBUG'] = stripe_debug_values()
         return ctx
 
@@ -163,6 +164,8 @@ class VerifyIdentityView(TemplateView):
                     stripe_acct.legal_entity.dob[field] = posted[field]
 
             stripe_acct.save()
+
+
 
         return redirect('bank')
 

--- a/static/js/codesy-app.js
+++ b/static/js/codesy-app.js
@@ -44,7 +44,7 @@ $(window).load(function () {
                 }
                 break;
             case 'bankAccount':
-                return ({id: stripe_bank_account}) =>{return {stripe_bank_account}};
+                return ({id: stripe_bank_account}) => {return {stripe_bank_account}};
                 break;
             default:
                 return ()=>{}

--- a/static/js/codesy-app.js
+++ b/static/js/codesy-app.js
@@ -44,7 +44,7 @@ $(window).load(function () {
                 }
                 break;
             case 'bankAccount':
-                return ({id: stripe_bank_account}) => {stripe_bank_account};
+                return ({id: stripe_bank_account}) =>{return {stripe_bank_account}};
                 break;
             default:
                 return ()=>{}


### PR DESCRIPTION
Added a "return_url" parameter to the bank url which is added by the claim form.  On a successful bank account setup, the codesy.app javascript redirects back to the claim form.

Test:

1) set up a new user or remove the Stripe bank account token from an existing user
2) approve a claim for the user
3) the claim status for the user should show the "register a bank account" message, click it.
4) the bank account form should load with "?return_url..." in the url
5) submit the form with and error like "asdf" in the routing number
6) you should be on the same form with an error message
7) change the routing number back to "110000000" and submit
8) you should return to the claime with the "Pay Me!" button
 
