### PR TITLE
Transfer Fee fix

### DIFF
--- a/payments/utils.py
+++ b/payments/utils.py
@@ -26,38 +26,40 @@ def calculate_codesy_fee(amount):
 
 
 def calculate_stripe_fee(amount):
-     return round_penny((amount * stripe_pct) + stripe_transaction)
+    return round_penny((amount * stripe_pct) + stripe_transaction)
 
 
 def transaction_amounts(amount):
     codesy_fee_amount = calculate_codesy_fee(amount)
     total_stripe_fee = calculate_stripe_fee(amount + codesy_fee_amount)
-	
-    #Offer stripe fee portion
-    offer_stripe_fee = total_stripe_fee / 2;
+
+    # offer stripe fee portion
+    offer_stripe_fee = total_stripe_fee / 2
 
     # this is the total to get charged to codesy's account
     charge_amount = amount + codesy_fee_amount + offer_stripe_fee
 
-    #following comment is optimal temp_payout calculation
+    # payout amount before transfer fee
     temp_payout = charge_amount - (2 * codesy_fee_amount) - total_stripe_fee
 
-    #calculate the final payout first to determine transfer fee
+    # calculate the final payout first to determine transfer fee
     payout_amount = temp_payout / (1 + stripe_transfer_pct)
 
-    #transfer fee should equal the difference between temp_payout and final_payout
+    # transfer fee equals the difference between temp and payout_amount
     transfer_fee = temp_payout - payout_amount
 
     # all the fees together
     application_fee = 2 * codesy_fee_amount + total_stripe_fee + transfer_fee
+
+    payout_stripe_fee = offer_stripe_fee
 
     return {
           'amount': amount,
           'codesy_fee': codesy_fee_amount,
           'total_stripe_fee': total_stripe_fee,
           'charge_amount': charge_amount,
-          'offer_strip_fee': offer_stripe_fee,
-          'temp_payout': temp_payout,
+          'offer_stripe_fee': offer_stripe_fee,
+          'payout_stripe_fee': payout_stripe_fee,
           'payout_amount': payout_amount,
           'transfer_fee': transfer_fee,
           'application_fee': application_fee

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -33,11 +33,11 @@ def transaction_amounts(amount):
 	stripe_fee_amount = calculate_stripe_fee(amount + codesy_fee_amount)
 	
 	# this is the total to get charged to codesy's account
-	charge_amount = amount + codesy_fee_amount + (stripe_fee_amount * 0.5)
+	charge_amount = amount + codesy_fee_amount + (stripe_fee_amount / 2)
 	
 	# this the charge amount then subtract codesy fee and half of stripe fee, that should equal initial reward payment amount
 	# then subtract codesy fee and other half of stripe fee for users share
-	temp_payout = charge_amount - codesy_fee_amount - (stripe_fee_amount * 0.5) - codesy_fee_amount - (stripe_fee_amount * 0.5)
+	temp_payout = charge_amount - codesy_fee_amount - (stripe_fee_amount / 2) - codesy_fee_amount - (stripe_fee_amount / 2)
 	
 	#following comment is optimal temp_payout calculation
 	# temp_payout = charge_amount - (2 * codesy_fee_amount) - stripe_fee_amount

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -37,32 +37,32 @@ def transaction_amounts(amount):
     offer_stripe_fee = total_stripe_fee / 2
 
     # this is the total to get charged to codesy's account
-    charge_amount = amount + codesy_fee_amount + offer_stripe_fee
+    charge_amount = round_penny(amount + codesy_fee_amount + offer_stripe_fee)
 
     # payout amount before transfer fee
-    temp_payout = charge_amount - (2 * codesy_fee_amount) - total_stripe_fee
+    temp_payout = round_penny(charge_amount - (2 * codesy_fee_amount) - total_stripe_fee)
 
     # calculate the final payout first to determine transfer fee
-    payout_amount = temp_payout / (1 + stripe_transfer_pct)
+    payout_amount = round_penny(temp_payout / (1 + stripe_transfer_pct))
 
     # transfer fee equals the difference between temp and payout_amount
-    transfer_fee = temp_payout - payout_amount
+    transfer_fee = round_penny(temp_payout - payout_amount)
 
     # all the fees together
-    application_fee = 2 * codesy_fee_amount + total_stripe_fee + transfer_fee
+    application_fee = round_penny(2 * codesy_fee_amount + total_stripe_fee + transfer_fee)
 
     payout_stripe_fee = offer_stripe_fee
 
     return {
-          'amount': amount,
-          'codesy_fee': codesy_fee_amount,
-          'total_stripe_fee': total_stripe_fee,
-          'charge_amount': charge_amount,
-          'offer_stripe_fee': offer_stripe_fee,
-          'payout_stripe_fee': payout_stripe_fee,
-          'payout_amount': payout_amount,
-          'transfer_fee': transfer_fee,
-          'application_fee': application_fee
+        'amount': amount,
+        'codesy_fee': codesy_fee_amount,
+        'total_stripe_fee': total_stripe_fee,
+        'charge_amount': charge_amount,
+        'offer_stripe_fee': offer_stripe_fee,
+        'payout_stripe_fee': payout_stripe_fee,
+        'payout_amount': payout_amount,
+        'transfer_fee': transfer_fee,
+        'application_fee': application_fee
      }
 
 

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -17,50 +17,50 @@ stripe_transaction = Decimal('0.30')
 stripe_transfer_pct = Decimal('0.005')
 
 def round_penny(amount):
-	return amount.quantize(Decimal('.01'), rounding=ROUND_HALF_UP)
+     return amount.quantize(Decimal('.01'), rounding=ROUND_HALF_UP)
 
 
 def calculate_codesy_fee(amount):
-	return round_penny(amount* codesy_pct)
+     return round_penny(amount* codesy_pct)
 
 
 def calculate_stripe_fee(amount):
-	return round_penny((amount* stripe_pct) + stripe_transaction)
+     return round_penny((amount* stripe_pct) + stripe_transaction)
 
 
 def transaction_amounts(amount):
-	codesy_fee_amount = calculate_codesy_fee(amount)
-	stripe_fee_amount = calculate_stripe_fee(amount + codesy_fee_amount)
+     codesy_fee_amount = calculate_codesy_fee(amount)
+     total_stripe_fee = calculate_stripe_fee(amount + codesy_fee_amount)
 	
-	# this is the total to get charged to codesy's account
-	charge_amount = amount + codesy_fee_amount + (stripe_fee_amount / 2)
-	
-	# this the charge amount then subtract codesy fee and half of stripe fee, that should equal initial reward payment amount
-	# then subtract codesy fee and other half of stripe fee for users share
-	temp_payout = charge_amount - codesy_fee_amount - (stripe_fee_amount / 2) - codesy_fee_amount - (stripe_fee_amount / 2)
-	
-	#following comment is optimal temp_payout calculation
-	# temp_payout = charge_amount - (2 * codesy_fee_amount) - stripe_fee_amount
-	
-	#calculate the final payout first to determine transfer fee
-	final_payout = temp_payout / (1 + stripe_transfer_pct)
-	
-	#transfer fee should equal the difference between temp_payout and final_payout
-	transfer_fee = temp_payout - final_payout
-	
-	# all the fees together
-	application_fee = 2 * codesy_fee_amount + stripe_fee_amount + transfer_fee
+     #Offer stripe fee portion
+     offer_stripe_fee = total_stripe_fee / 2;
+     
+     # this is the total to get charged to codesy's account
+     charge_amount = amount + codesy_fee_amount + offer_stripe_fee
 
-	return {
-		'amount': amount,
-        'codesy_fee': codesy_fee_amount,
-        'stripe_fee_amount': stripe_fee_amount,      
-        'charge_amount': charge_amount,
-        'temp_payout': temp_payout,
-        'final_payout': final_payout,
-        'transfer_fee': transfer_fee,
-        'application_fee': application_fee
-	}
+     #following comment is optimal temp_payout calculation
+     temp_payout = charge_amount - (2 * codesy_fee_amount) - total_stripe_fee
+
+     #calculate the final payout first to determine transfer fee
+     payout_amount = temp_payout / (1 + stripe_transfer_pct)
+
+     #transfer fee should equal the difference between temp_payout and final_payout
+     transfer_fee = temp_payout - payout_amount
+
+     # all the fees together
+     application_fee = 2 * codesy_fee_amount + stripe_fee_amount + transfer_fee
+
+     return {
+          'amount': amount,
+          'codesy_fee': codesy_fee_amount,
+          'total_stripe_fee': total_stripe_fee,
+          'charge_amount': charge_amount,
+          'offer_strip_fee' : offer_stripe_fee,
+          'temp_payout': temp_payout,
+          'final_payout': final_payout,
+          'transfer_fee': transfer_fee,
+          'application_fee': application_fee
+     }
 
 
 def refund(offer):

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -16,48 +16,49 @@ stripe_transaction = Decimal('0.30')
 # stripe charge of 0.5% for transfering to bank account
 stripe_transfer_pct = Decimal('0.005')
 
+
 def round_penny(amount):
-     return amount.quantize(Decimal('.01'), rounding=ROUND_HALF_UP)
+    return amount.quantize(Decimal('.01'), rounding=ROUND_HALF_UP)
 
 
 def calculate_codesy_fee(amount):
-     return round_penny(amount* codesy_pct)
+    return round_penny(amount * codesy_pct)
 
 
 def calculate_stripe_fee(amount):
-     return round_penny((amount* stripe_pct) + stripe_transaction)
+     return round_penny((amount * stripe_pct) + stripe_transaction)
 
 
 def transaction_amounts(amount):
-     codesy_fee_amount = calculate_codesy_fee(amount)
-     total_stripe_fee = calculate_stripe_fee(amount + codesy_fee_amount)
+    codesy_fee_amount = calculate_codesy_fee(amount)
+    total_stripe_fee = calculate_stripe_fee(amount + codesy_fee_amount)
 	
-     #Offer stripe fee portion
-     offer_stripe_fee = total_stripe_fee / 2;
-     
-     # this is the total to get charged to codesy's account
-     charge_amount = amount + codesy_fee_amount + offer_stripe_fee
+    #Offer stripe fee portion
+    offer_stripe_fee = total_stripe_fee / 2;
 
-     #following comment is optimal temp_payout calculation
-     temp_payout = charge_amount - (2 * codesy_fee_amount) - total_stripe_fee
+    # this is the total to get charged to codesy's account
+    charge_amount = amount + codesy_fee_amount + offer_stripe_fee
 
-     #calculate the final payout first to determine transfer fee
-     payout_amount = temp_payout / (1 + stripe_transfer_pct)
+    #following comment is optimal temp_payout calculation
+    temp_payout = charge_amount - (2 * codesy_fee_amount) - total_stripe_fee
 
-     #transfer fee should equal the difference between temp_payout and final_payout
-     transfer_fee = temp_payout - payout_amount
+    #calculate the final payout first to determine transfer fee
+    payout_amount = temp_payout / (1 + stripe_transfer_pct)
 
-     # all the fees together
-     application_fee = 2 * codesy_fee_amount + stripe_fee_amount + transfer_fee
+    #transfer fee should equal the difference between temp_payout and final_payout
+    transfer_fee = temp_payout - payout_amount
 
-     return {
+    # all the fees together
+    application_fee = 2 * codesy_fee_amount + total_stripe_fee + transfer_fee
+
+    return {
           'amount': amount,
           'codesy_fee': codesy_fee_amount,
           'total_stripe_fee': total_stripe_fee,
           'charge_amount': charge_amount,
-          'offer_strip_fee' : offer_stripe_fee,
+          'offer_strip_fee': offer_stripe_fee,
           'temp_payout': temp_payout,
-          'final_payout': final_payout,
+          'payout_amount': payout_amount,
           'transfer_fee': transfer_fee,
           'application_fee': application_fee
      }

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -32,8 +32,8 @@ def calculate_stripe_fee(amount):
 
 
 def calculate_stripe_transfer(amount):
-    return round_penny(amount 
-        - (amount / (1 + stripe_transfer_pct)
+    return round_penny(amount
+        - (amount / (1 + stripe_transfer_pct))
     )
 
 

--- a/payments/utils.py
+++ b/payments/utils.py
@@ -32,8 +32,8 @@ def calculate_stripe_fee(amount):
 
 
 def calculate_stripe_transfer(amount):
-    return round_penny(amount
-        - (amount / (1 + stripe_transfer_pct))
+    return round_penny(
+        amount - (amount / (1 + stripe_transfer_pct))
     )
 
 


### PR DESCRIPTION
I simplified the transaction function to calculate only what is needed, from how I understand the charge/payment process from the codesy website.  This may affect other source files that call the transaction amounts function since I deleted a few variables, which seemed to exist for testing purposes.  

The important change is that the final payout amount is determined by the initial payout divided by (1 + transfer_fee).  Transfer fee is then initial payout - final payout. #449 