### PR TITLE
for #579: send http header when auth changes

### DIFF
--- a/codesy/base/middleware.py
+++ b/codesy/base/middleware.py
@@ -1,0 +1,12 @@
+AUTH_CHANGING_PATHS = ['/accounts/logout/', '/accounts/github/login/callback/']
+
+
+class AuthChangedMiddleware(object):
+    """
+    Adds a custom HTTP header for the widget when auth state changes
+    """
+
+    def process_response(self, request, response):
+        if request.path in AUTH_CHANGING_PATHS:
+            response['x-codesy-auth-changed'] = 'true'
+        return response

--- a/codesy/settings.py
+++ b/codesy/settings.py
@@ -73,6 +73,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'payments.middleware.IdentityVerificationMiddleware',
+    'codesy.base.middleware.AuthChangedMiddleware'
 )
 
 


### PR DESCRIPTION
This should work, but now that I see its server-side implementation, the only thing that makes server-side better than detecting these requests paths on the client is future-proofing.

I.e., we can later update our `AUTH_CHANGING_PATHS` values on the server without pushing a new add-on update.