### PR TITLE
fix #579: use allauth messages for header

### DIFF
--- a/codesy/base/middleware.py
+++ b/codesy/base/middleware.py
@@ -1,4 +1,4 @@
-AUTH_CHANGING_PATHS = ['/accounts/logout/', '/accounts/github/login/callback/']
+from django.contrib import messages
 
 
 class AuthChangedMiddleware(object):
@@ -7,6 +7,14 @@ class AuthChangedMiddleware(object):
     """
 
     def process_response(self, request, response):
-        if request.path in AUTH_CHANGING_PATHS:
-            response['x-codesy-auth-changed'] = 'true'
+        for message in messages.get_messages(request):
+            if (
+                response.status_code == 200 and
+                (
+                    "Successfully signed in" in message.message or
+                    "You have signed out" in message.message
+                )
+            ):
+                response['x-codesy-auth-changed'] = 'true'
+
         return response

--- a/codesy/settings.py
+++ b/codesy/settings.py
@@ -71,9 +71,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'codesy.base.middleware.AuthChangedMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'payments.middleware.IdentityVerificationMiddleware',
-    'codesy.base.middleware.AuthChangedMiddleware'
 )
 
 
@@ -107,6 +107,7 @@ AUTH_USER_MODEL = 'base.User'
 # OAuth2View uses this for the callback_url protocol
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = config(
     'ACCOUNT_DEFAULT_HTTP_PROTOCOL', default='http')
+ACCOUNT_LOGOUT_REDIRECT_URL = '/'
 LOGIN_REDIRECT_URL = '/'
 SOCIALACCOUNT_ADAPTER = 'codesy.adapters.CodesySocialAccountAdapter'
 SOCIALACCOUNT_QUERY_EMAIL = True

--- a/codesy/templates/base.html
+++ b/codesy/templates/base.html
@@ -35,7 +35,7 @@
                             <li><a href="{% url 'card' %}">Credit Card</a></li>
                             <li><a href="{% url 'bank' %}">Bank Account</a></li>
                             <hr/>
-                            <li><a href="{% url 'account_logout' %}">Sign out</a></li>
+                            <li><form action="{% url 'account_logout' %}" method="post">{% csrf_token %}<input type="submit" class="button top-bar-dropdown-signout" value="Sign out"></form></li>
                         </ul>
                     </li>
                 {% endif %}

--- a/codesy/urls.py
+++ b/codesy/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.contrib.auth.views import LogoutView
 
 from . import views
 
@@ -12,7 +11,6 @@ urlpatterns = [
     url(r'^$', views.Home.as_view(), name='home'),
     url(r'^legal-info$', views.LegalInfo.as_view(), name='legal-info'),
     # allauth
-    url(r'^accounts/logout/$', LogoutView.as_view(), {'next_page': '/'}),
     url(r'^accounts/', include('allauth.urls')),
 
     # admin site

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.11.5
 PyGithub==1.26.0
 dj-database-url==0.4.0
 dj-static==0.0.6
-django-allauth==0.24.1
+django-allauth==0.32.0
 django-csp==3.1
 django-cors-headers==1.1.0
 django-mailer==1.2.2

--- a/static/css/codesy-home.css
+++ b/static/css/codesy-home.css
@@ -82,6 +82,10 @@ tr.total {
   background-color: #F5F5F5;
 }
 
+.top-bar-dropdown-signout {
+  margin: 0 1rem 1rem;
+}
+
 img {
     border-width:0;
 }


### PR DESCRIPTION
Okay, this way it actually sends the `x-codes-auth-changed` header in the `200` response so that both Chrome and Firefox widgets can detect it.