### PR TITLE
fix #626: use unicodecsv to write non-ascii csv

### DIFF
--- a/codesy/base/admin.py
+++ b/codesy/base/admin.py
@@ -1,4 +1,5 @@
-import csv
+# TODO: in python 3.x use built-in unicode csv
+import unicodecsv as csv
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
@@ -16,7 +17,7 @@ def download_user_csv(modeladmin, request, queryset):
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment;filename=users.csv'
 
-    writer = csv.writer(response)
+    writer = csv.writer(response, encoding='utf-8')
     field_names = ['username', 'first_name', 'last_name', 'email']
     writer.writerow(field_names)
     for obj in queryset:

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ static==1.1.1
 wsgiref==0.1.2
 cffi==1.5.2
 stripe==1.62.0
+unicodecsv==0.14.1


### PR DESCRIPTION
To test, add a non-ascii character to a first or last name value on your local machine - e.g., luké - then use https://127.0.0.1:8443/admin/base/user/ to download all the users as a csv.

It should work now!